### PR TITLE
add missing hover text color

### DIFF
--- a/patterns/elements/button/button.scss
+++ b/patterns/elements/button/button.scss
@@ -154,6 +154,7 @@
       &:focus {
         background-color: $background-color-hover-buttons-alternate;
         border-color: $border-color-hover-buttons-alternate;
+        color: $font-color-hover-buttons-alternate;
         span{
           color: $font-color-hover-buttons-alternate;
           i{


### PR DESCRIPTION
Seen on notariat-emmental.ch, the alternate button is missing its font color definition when hovered