### PR TITLE
Readd generic color: inherit for text as base for discussion

### DIFF
--- a/patterns/elements/text/text.scss
+++ b/patterns/elements/text/text.scss
@@ -1,6 +1,11 @@
 @import '../../../resources/sass/definitions';
 
 .iq-text {
+  
+  * {
+    color: inherit;
+  }
+  
   &.inverted {
     * {
       color: $color-standard-inverted;


### PR DESCRIPTION
We had to remove the generic inheritance for color on iq-text as it overrides the h1, h2 etc. settings.
This PR is for discussion

CSS in question:
`.iq-text { * { color: inherit;  } } `