### PR TITLE
Add patch for error in bootstrap_barrio templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "patches": {
       "drupal/linkit": {
         "[https://dgo.to/3105061]: Link attributes missing with bootstrap theme": "https://www.drupal.org/files/issues/2024-01-05/linkit-selector-6.1.x-3105061-8.diff"
+      },
+      "drupal/bootstrap_barrio": {
+        "[https://dgo.to/3421337]: Unexpected token \"name\" of value \"if\"": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/75/diffs.diff?diff_id=758849"
       }
     }
   }


### PR DESCRIPTION
This PR adds a patch for drupal/bootstrap_barrio to fix some errors in templates.
See https://www.drupal.org/project/bootstrap_barrio/issues/3421337