### PR TITLE
DUP-28: Removed `version` key from library

### DIFF
--- a/iq_barrio.libraries.yml
+++ b/iq_barrio.libraries.yml
@@ -1,5 +1,4 @@
 global-styling:
-  version: VERSION
   js:
     resources/js/global.js: {}
   css:


### PR DESCRIPTION
We have `version: VERSION` set in our `*.libraries.yml` which leads to aggregated files always having the same hash and thus it is not guaranteed that cache is busted for clients/browsers. Remove it to solve the issue.