### PR TITLE
DUP-74: Upgrade to ckeditor5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
       "drupal/bootstrap_barrio": {
         "[https://dgo.to/3421337]: Unexpected token \"name\" of value \"if\"": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/75/diffs.diff?diff_id=758849",
         "[https://dgo.to/3222326]: Libraries should be improved": "https://www.drupal.org/files/issues/2025-03-19/library_improvements_and_fix_3222326_6.patch",
-        "DUP-74: Upgrade to CkEditor5": "./patches/bootstrap_barrio_ckeditor5_upgrade.patch"
+        "DUP-74: Upgrade to CkEditor5": "themes/custom/iq_barrio/patches/bootstrap_barrio_ckeditor5_upgrade.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
       },
       "drupal/bootstrap_barrio": {
         "[https://dgo.to/3421337]: Unexpected token \"name\" of value \"if\"": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/75/diffs.diff?diff_id=758849",
-        "[https://dgo.to/3222326]: Libraries should be improved": "https://www.drupal.org/files/issues/2025-03-19/library_improvements_and_fix_3222326_6.patch"
+        "[https://dgo.to/3222326]: Libraries should be improved": "https://www.drupal.org/files/issues/2025-03-19/library_improvements_and_fix_3222326_6.patch",
+        "DUP-74: Upgrade to CkEditor5": "./patches/bootstrap_barrio_ckeditor5_upgrade.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
       "drupal/bootstrap_barrio": {
         "[https://dgo.to/3421337]: Unexpected token \"name\" of value \"if\"": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/75/diffs.diff?diff_id=758849",
         "[https://dgo.to/3222326]: Libraries should be improved": "https://www.drupal.org/files/issues/2025-03-19/library_improvements_and_fix_3222326_6.patch",
-        "DUP-74: Upgrade to CkEditor5": "themes/custom/iq_barrio/patches/bootstrap_barrio_ckeditor5_upgrade.patch"
+        "DUP-74: Upgrade to CkEditor5": "public/themes/custom/iq_barrio/patches/bootstrap_barrio_ckeditor5_upgrade.patch"
       }
     }
   }

--- a/iq_barrio.info.yml
+++ b/iq_barrio.info.yml
@@ -19,7 +19,7 @@ libraries-extend:
   webform/webform.form:
     - bootstrap_barrio/form
 
-ckeditor_stylesheets:
+ckeditor5-stylesheets:
   - resources/css/ckeditor.css
 
 regions:

--- a/patches/bootstrap_barrio_ckeditor5_upgrade.patch
+++ b/patches/bootstrap_barrio_ckeditor5_upgrade.patch
@@ -1,0 +1,94 @@
+diff --git a/bootstrap_barrio.info.yml b/bootstrap_barrio.info.yml
+index 0e1c6f0..448974a 100644
+--- a/bootstrap_barrio.info.yml
++++ b/bootstrap_barrio.info.yml
+@@ -16,8 +16,8 @@ libraries-extend:
+   views/views.ajax:
+     - bootstrap_barrio/views.ajax
+ 
+-ckeditor_stylesheets:
+-  - css/components/table.css
++ckeditor5-stylesheets:
++  - css/components/ckeditor5.css
+ 
+ regions:
+   top_header: 'Top header'
+diff --git a/css/components/ckeditor5.css b/css/components/ckeditor5.css
+new file mode 100644
+index 0000000..e3e6de6
+--- /dev/null
++++ b/css/components/ckeditor5.css
+@@ -0,0 +1,72 @@
++/**
++ * @file
++ * Styles for Bootstrap Barrio's tables in ckeditor5.
++ */
++
++ .ck-content table {
++    border: 0;
++    border-spacing: 0;
++    font-size: 0.857em;
++    margin: 10px 0;
++    width: 100%;
++  }
++  .ck-content table table {
++    font-size: 1em;
++  }
++  .ck-content tr {
++    border-bottom: 1px solid #ccc;
++    padding: 0.1em 0.6em;
++    background: #efefef;
++    background: rgba(0, 0, 0, 0.063);
++  }
++  .ck-content thead > tr {
++    border-bottom: 1px solid #000;
++  }
++  .ck-content tr.odd {
++    background: #e4e4e4;
++    background: rgba(0, 0, 0, 0.105);
++  }
++  .ck-content table tr th {
++    background: #757575;
++    background: rgba(0, 0, 0, 0.51);
++    border-bottom-style: none;
++  }
++  .ck-content table tr th,
++  .ck-content table tr th a,
++  .ck-content table tr th a:hover,
++  .ck-content table tr th a:focus {
++    color: #fff;
++    font-weight: bold;
++  }
++  .ck-content table tbody tr th {
++    vertical-align: top;
++  }
++  .ck-content tr td,
++  .ck-content tr th {
++    padding: 4px 9px;
++    border: 1px solid #fff;
++    text-align: left; /* LTR */
++  }
++  [dir="rtl"] .ck-content tr td,
++  [dir="rtl"] .ck-content tr th {
++    text-align: right;
++  }
++  
++  /**
++   * Responsive tables.
++   */
++  @media screen and (max-width: 37.5em) { /* 600px */
++    .ck-content th.priority-low,
++    .ck-content td.priority-low,
++    .ck-content th.priority-medium,
++    .ck-content td.priority-medium {
++      display: none;
++    }
++  }
++  @media screen and (max-width: 60em) { /* 920px */
++    .ck-content th.priority-low,
++    .ck-content td.priority-low {
++      display: none;
++    }
++  }
++  
+


### PR DESCRIPTION
This PR is prepare the iq_barrio theme for the upgrade to CKEditor 5.

## Context
Ckeditor4 has been removed from core and replaced by CKEditor5.
Themes need as well to be adjusted, see https://www.drupal.org/node/3259165

## Change

- Use ckeditor5 stylesheet option to add custom style. 