### PR TITLE
Issue/dup 285 add jquery deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "[https://dgo.to/3421337]: Unexpected token \"name\" of value \"if\"": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/75/diffs.diff?diff_id=758849",
         "[https://dgo.to/3222326]: Libraries should be improved": "https://www.drupal.org/files/issues/2025-03-19/library_improvements_and_fix_3222326_6.patch",
         "[https://dgo.to/3549772]: Support for CkEditor5": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/113.diff"
+      },
+      "drupal/jquery_deprecated_functions": {
+        "[https://dgo.to/3567201]: Add other deprecated functions": "https://git.drupalcode.org/project/jquery_deprecated_functions/-/merge_requests/19/diffs?diff_id=1933057"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "[https://dgo.to/3549772]: Support for CkEditor5": "https://git.drupalcode.org/project/bootstrap_barrio/-/merge_requests/113.diff"
       },
       "drupal/jquery_deprecated_functions": {
-        "[https://dgo.to/3567201]: Add other deprecated functions": "https://git.drupalcode.org/project/jquery_deprecated_functions/-/merge_requests/19/diffs?diff_id=1933057"
+        "[https://dgo.to/3567201]: Add other deprecated functions": "https://git.drupalcode.org/project/jquery_deprecated_functions/-/merge_requests/19/diffs.diff?diff_id=1933057"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "php": "^8.1",
     "drupal/core": "^10 || ^11",
     "drupal/bootstrap_barrio": "~5.1.0",
+    "drupal/jquery_deprecated_functions": "^1.0",
     "drupal/linkit": "^7.0",
     "iqual/iq_barrio_composer_update": "^3.1",
     "iqual/iq_barrio_helper": "^4.2",

--- a/iq_barrio.info.yml
+++ b/iq_barrio.info.yml
@@ -8,8 +8,9 @@ base theme: bootstrap_barrio
 'interface translation server pattern': themes/custom/iq_barrio/translations/iq_barrio-%language.po
 
 dependencies:
-  - iq_barrio_helper
-  - pagedesigner_responsive_images
+  - iq_barrio_helper:iq_barrio_helper
+  - pagedesigner_responsive_images:pagedesigner_responsive_images
+  - jquery_deprecated_functions:jquery_deprecated_functions
 
 libraries:
   - iq_barrio/global-styling


### PR DESCRIPTION
This PR adds drupal/jquery_deprecated_functions module as iq_barrio dependencies to replace removed jquery 3 functions from drupal core jquery 4