### PR TITLE
DUP-279: Optimize styling for CKEditor 5

### DIFF
--- a/resources/sass/ckeditor.scss
+++ b/resources/sass/ckeditor.scss
@@ -1,13 +1,9 @@
 @import 'definitions';
 
-.gjs-editor.gjs-editor {
-  .ck-editor .ck-content {
-    * {
-      color: $color-standard;
-    }
-    a {
-      font-size: inherit;
-    }
-    @import 'style.scss';
+.gjs-editor.gjs-editor .ck-editor .ck-content {
+  * {
+    all: revert;
+    @include font-standard;
   }
+  @import 'style.scss';
 }


### PR DESCRIPTION
This pull request refines the styling of the CKEditor content within the `.gjs-editor` context. The main change is to reset all styles using `all: revert` and apply the standard font, which improves consistency and prevents unwanted style inheritance.

Editor styling improvements:

* Changed the `.gjs-editor.gjs-editor .ck-editor .ck-content` selector to apply `all: revert` and the standard font mixin to all child elements, ensuring more predictable and consistent editor appearance.
* Removed explicit color and font-size overrides, relying instead on the reset and font mixin for style normalization.