### PR TITLE
PF-462: Add support for `prefers-reduced-motion` in slider

### DIFF
--- a/patterns/composite/slider/slider.js
+++ b/patterns/composite/slider/slider.js
@@ -1,5 +1,6 @@
 (function ($, Drupal) {
   function slider(sliders) {
+    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     sliders.each(function (i, slider) {
       $slider = $(slider);
@@ -17,7 +18,7 @@
         config.margin = parseInt($slider.data('margin'));
       }
 
-      if ($slider.data('autoplay')) {
+      if ($slider.data('autoplay') && !prefersReducedMotion) {
         config.autoplay = true;
 //        config.autoplayHoverPause = true;
         if ($slider.data('duration')) {


### PR DESCRIPTION
## Issue

Currently visual regression testing can fail on pages using the owl carousel using the autoplay option. Since that's a javascript animation. This should not be animated if the user has set `prefers-reduced-motion` to `reduce`. This has also the nice benefit of improving accessibiltiy.

## Tasks

- [x] Add support for `prefers-reduced-motion` in owl slider

## Testing

* [Emulate CSS media features in Chrome devconsole](https://developer.chrome.com/docs/devtools/rendering/emulate-css#emulate_css_media_feature_prefers-reduced-motion)