### PR TITLE
UUN-1548: use original image for lightbox

### DIFF
--- a/patterns/elements/img/img.js
+++ b/patterns/elements/img/img.js
@@ -1,7 +1,6 @@
 (function ($, Drupal) {
   function image($images) {
     $images.each(function (i, a) {
-      $(a).attr('href', $(a).find('img').attr('src'));
       $(a).on('click', function (e) {
         e.preventDefault();
         $(this).ekkoLightbox();

--- a/patterns/elements/img/pattern-img.html.twig
+++ b/patterns/elements/img/pattern-img.html.twig
@@ -1,7 +1,7 @@
 <div class="iq-image" data-align="{{alignment}}">
 
   {% if lightbox|render == 'lightbox' %}
-    <a href="{{img['img_original']}}" data-toggle="{{lightbox}}-single-image"  data-max-width="1920" data-title="{{image_alt}}">
+    <a href="{{ file_url(image_img|render)}}" data-toggle="{{lightbox}}-single-image"  data-max-width="1920" data-title="{{image_alt}}">
   {% else %}
     {% if href|render is not empty %}
       <a href="{{href}}" title="{{title_link}}" target="{{link_target}}" {% if link_target|render == '_blank' %}rel="noopener"{% endif %}>


### PR DESCRIPTION
This pull request updates the image lightbox functionality to ensure that the correct image URL is used for the lightbox link, and removes redundant JavaScript code that set the link's `href` attribute. The changes improve reliability and maintainability of the image pattern.

Image lightbox improvements:

* Updated the anchor tag in `pattern-img.html.twig` to use the rendered image URL via `file_url(image_img|render)` instead of the previous `img['img_original']` variable, ensuring the correct image path is used for the lightbox.

Code cleanup:

* Removed JavaScript code in `img.js` that set the anchor's `href` attribute to the image's `src`, as this is now handled in the template and is no longer necessary.